### PR TITLE
ユーザー制御のメソッド追加

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -1,5 +1,6 @@
 class BooksController < ApplicationController
   before_action :set_book, only: [:show, :edit, :update, :destroy]
+  before_action :ensure_correct_user, only: %i(edit update destroy)
 
   # GET /books
   # GET /books.json
@@ -72,5 +73,13 @@ class BooksController < ApplicationController
     # Never trust parameters from the scary internet, only allow the white list through.
     def book_params
       params.require(:book).permit(:title, :memo, :author, :picture)
+    end
+
+    def ensure_correct_user
+      set_book
+      if @book.user_id != current_user.id
+        flash[:notice] = "権限がありません"
+        redirect_to @book
+      end
     end
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,6 +1,7 @@
 class CommentsController < ApplicationController
   before_action :set_commentable
   before_action :set_comment, only: [:show, :edit, :update, :destroy]
+  before_action :ensure_correct_user, only: %i(edit update destroy)
 
   # GET /comments
   # GET /comments.json
@@ -65,5 +66,13 @@ class CommentsController < ApplicationController
     # Never trust parameters from the scary internet, only allow the white list through.
     def comment_params
       params.require(:comment).permit(:title, :body)
+    end
+
+    def ensure_correct_user
+      set_comment
+      if @comment.user_id != current_user.id
+        flash[:notice] = "権限がありません"
+        redirect_to [@commentable, @comment]
+      end
     end
 end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,5 +1,6 @@
 class ReportsController < ApplicationController
   before_action :set_report, only: [:show, :edit, :update, :destroy]
+  before_action :ensure_correct_user, only: %i(edit update destroy)
 
   # GET /reports
   # GET /reports.json
@@ -72,5 +73,13 @@ class ReportsController < ApplicationController
     # Never trust parameters from the scary internet, only allow the white list through.
     def report_params
       params.require(:report).permit(:title, :memo)
+    end
+
+    def ensure_correct_user
+      set_report
+      if @report.user_id != current_user.id
+        flash[:notice] = "権限がありません"
+        redirect_to @report
+      end
     end
 end


### PR DESCRIPTION
##  追加
ensure_correnct_userメソッドにより、特定のパスにユーザーがアクセスできないよう制御
 - ログインユーザーによる投稿かどうかを判断